### PR TITLE
Windows: fix frozen cl.exe processes after jam.exe is terminated

### DIFF
--- a/jam_src/jam.c
+++ b/jam_src/jam.c
@@ -175,7 +175,7 @@ extern char **environ;
 # endif
 # endif
 
-#define JAMBUILDSTR "1.2-2023/04/14"
+#define JAMBUILDSTR "1.3-2024/03/12"
 
 int main(int argc, char **argv, char **arg_environ)
 {

--- a/jam_src/win32spawnl.c
+++ b/jam_src/win32spawnl.c
@@ -43,6 +43,11 @@ intptr_t _win32_spawn(const char *cmdname, const char *params, ExecOutputFilter 
   if (!CreatePipe (&output_read, &output_write, &sa, 0))
     return -1;
 
+  // Disable parent process pipe handle inheritance
+  // https://learn.microsoft.com/en-us/windows/win32/procthread/creating-a-child-process-with-redirected-input-and-output
+  if (!SetHandleInformation(output_read, HANDLE_FLAG_INHERIT, 0))
+    goto err_exit_0;
+
   if (!DuplicateHandle(hProc, output_write, hProc, &stdout_write, 0, TRUE, DUPLICATE_SAME_ACCESS))
     goto err_exit_0;
   if (!DuplicateHandle (hProc, output_write, hProc, &stderr_write, 0, TRUE, DUPLICATE_SAME_ACCESS))


### PR DESCRIPTION
Windows is the only OS affected.

The problem is reproduced by terminating jam.exe in the middle of the build with multiple cl.exe running.

It is caused by cl.exe trying to write to stdout while parent process is dies and pipe buffer is full.
And compiler is expected to print all included file names which generates plenty of data.

Simple workaround is to increase pipe buffer to a size which is bigger than any expected compiler output.

Another possible solution could be to run some guard process by jam.exe. The guard will wait until its parent process died and will kill all children of it parent (skipping itself).