### PR TITLE
implement unix glob via scandir instead of readdir

### DIFF
--- a/jam_src/fileunix.c
+++ b/jam_src/fileunix.c
@@ -109,9 +109,11 @@ file_dirscan(
 	scanback func,
 	void *closure )
 {
+	int n;
 	PATHNAME f;
 	DIR *d;
 	STRUCT_DIRENT *dirent;
+	STRUCT_DIRENT **namelist;
 	char filename[ MAXJPATH ];
 
 	/* First enter directory itself */
@@ -130,14 +132,15 @@ file_dirscan(
 
 	/* Now enter contents of directory */
 
-	if( !( d = opendir( dir ) ) )
+	if ( ( n = scandir( dir, &namelist, NULL, alphasort ) ) < 0 )
 	    return;
 
 	if( DEBUG_BINDSCAN )
 	    printf( "scan directory %s\n", dir );
 
-	while( dirent = readdir( d ) )
+	while( n-- )
 	{
+	    dirent = namelist[n];
 # ifdef old_sinix
 	    /* Broken structure definition on sinix. */
 	    f.f_base.ptr = dirent->d_name - 2;
@@ -149,9 +152,11 @@ file_dirscan(
 	    path_build( &f, filename, 0 );
 
 	    (*func)( closure, filename, 0 /* not stat()'ed */, (time_t)0 );
+
+	    free( dirent );
 	}
 
-	closedir( d );
+	free( namelist );
 }
 
 /*

--- a/jam_src/jam.c
+++ b/jam_src/jam.c
@@ -171,7 +171,7 @@ extern char **environ;
 # endif
 # endif
 
-#define JAMBUILDSTR "1.31-2025/02/04"
+#define JAMBUILDSTR "1.32-2025/08/19"
 
 int main(int argc, char **argv, char **arg_environ)
 {


### PR DESCRIPTION
It's has builting facility for sorting which is important for deterministics/reproducible builds (same order of modules regadless of filesystem state)

Same as in boost jam:
https://github.com/boostorg/build/commit/7aa74e3029c4b3b5a1c42dea5d66891b88c576a4

Related
https://man7.org/linux/man-pages/man3/scandir.3.html https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/scandir.3.html