### PR TITLE
direct scandir namelist iteration

### DIFF
--- a/jam_src/fileunix.c
+++ b/jam_src/fileunix.c
@@ -109,7 +109,7 @@ file_dirscan(
 	scanback func,
 	void *closure )
 {
-	int n;
+	int n, i;
 	PATHNAME f;
 	DIR *d;
 	STRUCT_DIRENT *dirent;
@@ -138,9 +138,9 @@ file_dirscan(
 	if( DEBUG_BINDSCAN )
 	    printf( "scan directory %s\n", dir );
 
-	while( n-- )
+	for (i = 0; i < n; ++i)
 	{
-	    dirent = namelist[n];
+	    dirent = namelist[i];
 # ifdef old_sinix
 	    /* Broken structure definition on sinix. */
 	    f.f_base.ptr = dirent->d_name - 2;


### PR DESCRIPTION
Quick follow-up to previous PR
(https://github.com/GaijinEntertainment/jam-G8/pull/7 ) Use direct (forward) iteration as it seems to be closer to what de-facto happens on new checkout (what readdir was returning)