### PR TITLE
Treat changed jam scripts as forced rebuild

### DIFF
--- a/jam_src/changedPaths.c
+++ b/jam_src/changedPaths.c
@@ -65,8 +65,10 @@ typedef struct {
 
 static cp_FileSet g_files;
 static cp_DirVec  g_dirs;
+static cp_DirVec  g_parsed;	/* raw paths of every parsed jam script */
 static int        g_loaded   = 0;
 static int        g_walk_gen = 0;
+static int        g_jamfile_changed = 0;	/* any parsed file in change set */
 
 /*
  * Both the changed-paths list entries and the walked TARGET boundnames
@@ -562,11 +564,38 @@ changed_paths_load( const char *list_file )
 
 	g_loaded = 1;
 
+	/*
+	 * Check every jam-script file that parse_file() recorded against
+	 * the just-loaded change set.  If any parsed Jamfile (top-level
+	 * or transitively included) is in the change set, force the
+	 * build to proceed: Jamfile changes can rewire the dependency
+	 * graph in ways the post-make0 walk cannot detect (a target may
+	 * have been added, removed, or had its sources changed).
+	 */
+	g_jamfile_changed = 0;
+	{
+	    int   i;
+	    char  abs[8192];
+	    for ( i = 0; i < g_parsed.count; i++ ) {
+		cp_make_abs( abs, sizeof( abs ), g_parsed.arr[i], g_jam_cwd );
+		cp_canon( abs );
+		if ( abs[0] && ( cp_fs_contains( &g_files, abs ) ||
+				 cp_dv_contains_prefix( &g_dirs, abs ) ) ) {
+		    g_jamfile_changed = 1;
+		    if ( DEBUG_DEPENDS )
+			printf( "JamChangedFilesPath: jamfile in change set: '%s'\n", abs );
+		    break;
+		}
+	    }
+	}
+
 	if ( DEBUG_DEPENDS ) {
 	    printf( "JamChangedFilesPath: loaded %d files, %d dirs from '%s'\n",
 		g_files.count, g_dirs.count, list_file );
 	    printf( "JamChangedFilesPath: cwd='%s' root='%s'\n",
 		g_jam_cwd, g_changed_root );
+	    printf( "JamChangedFilesPath: parsed jam files tracked: %d\n",
+		g_parsed.count );
 	}
 
 	return 1;
@@ -632,8 +661,23 @@ cp_walk( TARGET *t, int gen )
 int
 changed_paths_test( TARGET *t )
 {
+	if ( g_jamfile_changed )
+	    return 1;
 	g_walk_gen++;
 	if ( !g_walk_gen ) /* skip 0 (the un-visited sentinel) on wraparound */
 	    g_walk_gen = 1;
 	return cp_walk( t, g_walk_gen );
+}
+
+void
+changed_paths_register_parsed_file( const char *path )
+{
+	if ( !path || !path[0] )
+	    return;
+	/* "+" is jam's sigil for the precompiled built-in Jambase
+	 * (jambase.c) -- there is no file on disk and nothing for the
+	 * change-set to match. */
+	if ( path[0] == '+' && path[1] == 0 )
+	    return;
+	cp_dv_push( &g_parsed, path );
 }

--- a/jam_src/changedPaths.h
+++ b/jam_src/changedPaths.h
@@ -36,4 +36,15 @@ int  changed_paths_load( const char *list_file );
 int  changed_paths_test( struct _target *t );
 void changed_paths_free( void );
 
+/*
+ * Called from parse_file() to record every jam-script file that's
+ * been parsed (top-level via -f, default jamfile, every `include`).
+ * These files are NOT in the TARGET dependency graph but their
+ * contents drive the build, so we must short-circuit to "proceed"
+ * when any of them is in the changed-paths set.  The "+" sigil
+ * (internal precompiled Jambase) and NULL inputs are silently
+ * ignored.  Safe to call before changed_paths_load.
+ */
+void changed_paths_register_parsed_file( const char *path );
+
 #endif /* CHANGED_PATHS_H */

--- a/jam_src/parse.c
+++ b/jam_src/parse.c
@@ -20,6 +20,7 @@
 # include "parse.h"
 # include "scan.h"
 # include "newstr.h"
+# include "changedPaths.h"
 
 static PARSE *yypsave;
 
@@ -28,6 +29,8 @@ parse_file( const char *f )
 {
 	/* Suspend scan of current file */
 	/* and push this new file in the stream */
+
+	changed_paths_register_parsed_file( f );
 
 	yyfparse(f);
 


### PR DESCRIPTION
## Summary

Follow-up to #11 (already merged). Fixes a correctness gap: when a
Jamfile (top-level or any file pulled in via `include`) is in the
`JamChangedFilesPath` change set, jam wrongly reported "no targets
affected" and skipped the build.

## Motivation

PR #11's walker visits only TARGET nodes that the dependency graph
already contains. Jam scripts themselves are parsed before make0 and
they drive the *construction* of the graph (declaring targets,
adding `Depends` edges, registering sources, etc.), but they are not
TARGETs that anything depends on. So a Jamfile-only change was
invisible to the walker -- the graph had nothing to match against.

The miss is real and dangerous: changing a Jamfile can add, remove,
or rewire any number of targets, and skipping the build in that case
ships stale binaries.

## Fix

Track every file that `parse_file()` reads. That single funnel
covers:

- the top-level Jamfile (jam.c: `-f` or default `jamfile`), and
- every `include` rule (compile.c:354 calls `parse_file(t->boundname)`).

The `+` sigil for the precompiled built-in Jambase (`jambase.c`) is
silently skipped -- it has no file on disk.

- New public API:
  `changed_paths_register_parsed_file(const char *path)` (changedPaths.h).
- `parse.c` calls it at the entry of `parse_file()`.
- `changed_paths_load()` walks the registered list once, canonicalizes
  each path against `$(JAM_CWD)`, and sets `g_jamfile_changed` if any
  path is in the change set.
- `changed_paths_test()` short-circuits to "match" when the flag is
  set, before the per-target dep walk.

Footprint: 58 LoC added across `changedPaths.{c,h}` and `parse.c`,
additions only. No edits to existing logic.

## Test plan

**Synthetic project** with `include extra.jam`:

```sh
$ echo extra.jam > list.txt
$ jam -sJamChangedFilesPath=list.txt -d+13 all
JamChangedFilesPath: jamfile in change set: 'f:/research/jam-test/extra.jam'
...
BuildOut out.txt    # proceeds, as expected
```

**Dagor active_matter project** with `prog/daNetGame/target_name_rules.jam` in the list:

```sh
$ echo prog/daNetGame/target_name_rules.jam > changed.txt
$ jam ... -sJamChangedPathsRoot=F:/dagor_clean_5 -sJamChangedFilesPath=changed.txt -d+13
JamChangedFilesPath: jamfile in change set: 'f:/dagor_clean_5/prog/danetgame/target_name_rules.jam'
JamChangedFilesPath: parsed jam files tracked: 1641
...
SUCCESSFULLY built active_matter-aot-windows-x86_64-c-dev.exe
```

The 1641 number is Dagor's full `_jBuild` include closure -- captured
automatically because every script flows through `parse_file()`.

## Backward compatibility

- When `JamChangedFilesPath` is unset, behavior is byte-identical to
  upstream `3843977`.
- When set with no jamfile in the change set, the per-target walk
  proceeds exactly as before -- no behavior change.
- The new short-circuit only fires when the user explicitly lists a
  jam script as changed.
